### PR TITLE
added 'DO' macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ profile
 
 #testing code
 iPhone Demo App/*
+MACollectionUtilities
+
+MACollectionUtilities.dSYM/Contents/Info.plist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: objective-c
+xcode_project: MACollectionUtilities.xcodeproj
+xcode_scheme: MACollectionUtilities

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 language: objective-c
-xcode_project: MACollectionUtilities.xcodeproj
-xcode_scheme: MACollectionUtilities
+script: "./run-tests.sh"

--- a/MACollectionUtilities.h
+++ b/MACollectionUtilities.h
@@ -31,6 +31,8 @@
 #define REJECT(collection, ...) EACH_WRAPPER([collection ma_select: ^BOOL (id obj) { return (__VA_ARGS__) == 0; }])
 #define MATCH(collection, ...) EACH_WRAPPER([collection ma_match: ^BOOL (id obj) { return (__VA_ARGS__) != 0; }])
 #define REDUCE(collection, initial, ...) EACH_WRAPPER([collection ma_reduce: (initial) block: ^id (id a, id b) { return (__VA_ARGS__); }])
+#define DO(collection, ...) ([collection ma_do: ^void (id obj) { __VA_ARGS__; }])
+
 
 #define EACH(array) MAEachHelper(array, &MA_eachTable)
 
@@ -42,6 +44,7 @@
 - (NSArray *)ma_select: (BOOL (^)(id obj))block;
 - (id)ma_match: (BOOL (^)(id obj))block;
 - (id)ma_reduce: (id)initial block: (id (^)(id a, id b))block;
+- (void)ma_do: (void (^)(id obj))block;
 
 - (NSArray *)ma_sorted: (BOOL (^)(id a, id b))lessThan;
 
@@ -52,6 +55,7 @@
 - (NSSet *)ma_map: (id (^)(id obj))block;
 - (NSSet *)ma_select: (BOOL (^)(id obj))block;
 - (id)ma_match: (BOOL (^)(id obj))block;
+- (void)ma_do: (void (^)(id obj))block;
 
 - (NSArray *)ma_sorted: (BOOL (^)(id a, id b))lessThan;
 

--- a/MACollectionUtilities.h
+++ b/MACollectionUtilities.h
@@ -31,7 +31,7 @@
 #define REJECT(collection, ...) EACH_WRAPPER([collection ma_select: ^BOOL (id obj) { return (__VA_ARGS__) == 0; }])
 #define MATCH(collection, ...) EACH_WRAPPER([collection ma_match: ^BOOL (id obj) { return (__VA_ARGS__) != 0; }])
 #define REDUCE(collection, initial, ...) EACH_WRAPPER([collection ma_reduce: (initial) block: ^id (id a, id b) { return (__VA_ARGS__); }])
-#define DO(collection, ...) ([collection ma_do: ^void (id obj) { __VA_ARGS__; }])
+#define DO(collection, ...) EACH_WRAPPER_NORETURN([collection ma_do: ^void (id obj) { __VA_ARGS__;}])
 
 
 #define EACH(array) MAEachHelper(array, &MA_eachTable)
@@ -73,6 +73,13 @@
             CFRelease(MA_eachTable); \
         return MA_retval; \
     }())
+
+#define EACH_WRAPPER_NORETURN(...) (^{ __block CFMutableDictionaryRef MA_eachTable = nil; \
+		(void)MA_eachTable; \
+		__VA_ARGS__; \
+		if(MA_eachTable) \
+			CFRelease(MA_eachTable); \
+	}())
 
 static inline NSDictionary *MADictionaryWithKeysAndObjects(id *keysAndObjs, NSUInteger count)
 {

--- a/MACollectionUtilities.m
+++ b/MACollectionUtilities.m
@@ -56,6 +56,12 @@
     }];
 }
 
+- (void)ma_do: (void (^)(id obj))block
+{
+	for(id obj in self)
+		block(obj);
+}
+
 @end
 
 @implementation NSSet (MACollectionUtilities)
@@ -88,6 +94,12 @@
 - (NSArray *)ma_sorted: (BOOL (^)(id a, id b))lessThan
 {
     return [[self allObjects] ma_sorted: lessThan];
+}
+
+- (void)ma_do: (void (^)(id obj))block
+{
+	for(id obj in self)
+		block(obj);
 }
 
 @end

--- a/MACollectionUtilities.xcodeproj/project.pbxproj
+++ b/MACollectionUtilities.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D980C3E1A66798100614AB5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C2F271B012639D0D00390827 /* main.m */; };
 		8DD76F9C0486AA7600D96B5E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08FB779EFE84155DC02AAC07 /* Foundation.framework */; };
 		C2F271AE12639D0800390827 /* MACollectionUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C2F271AD12639D0800390827 /* MACollectionUtilities.m */; };
-		C2F271B112639D0D00390827 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C2F271B012639D0D00390827 /* main.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -144,8 +144,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D980C3E1A66798100614AB5 /* main.m in Sources */,
 				C2F271AE12639D0800390827 /* MACollectionUtilities.m in Sources */,
-				C2F271B112639D0D00390827 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MACollectionUtilities.xcodeproj/project.pbxproj
+++ b/MACollectionUtilities.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 /* Begin PBXProject section */
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "MACollectionUtilities" */;
 			compatibilityVersion = "Xcode 3.1";
 			developmentRegion = English;
@@ -154,12 +156,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = MACollectionUtilities;
+				SDKROOT = macosx10.9;
 				WARNING_CFLAGS = (
 					"-W",
 					"-Wall",
@@ -172,10 +176,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = MACollectionUtilities;
+				SDKROOT = macosx10.9;
 				WARNING_CFLAGS = (
 					"-W",
 					"-Wall",
@@ -187,26 +193,26 @@
 		1DEB927908733DD40010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx10.9;
 			};
 			name = Debug;
 		};
 		1DEB927A08733DD40010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx10.9;
 			};
 			name = Release;
 		};

--- a/MACollectionUtilities.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MACollectionUtilities.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:MACollectionUtilities.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/MACollectionUtilities.xcodeproj/project.xcworkspace/xcshareddata/MACollectionUtilities.xccheckout
+++ b/MACollectionUtilities.xcodeproj/project.xcworkspace/xcshareddata/MACollectionUtilities.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>A60DFC6A-8251-4093-8F05-1A57700E3B03</string>
+	<key>IDESourceControlProjectName</key>
+	<string>MACollectionUtilities</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>271D05AC0C9B438269705BE4ECB02D2B75F9FDCB</key>
+		<string>https://github.com/iljaiwas/MACollectionUtilities.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>MACollectionUtilities.xcodeproj</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>271D05AC0C9B438269705BE4ECB02D2B75F9FDCB</key>
+		<string>../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>https://github.com/iljaiwas/MACollectionUtilities.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>111</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>271D05AC0C9B438269705BE4ECB02D2B75F9FDCB</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>271D05AC0C9B438269705BE4ECB02D2B75F9FDCB</string>
+			<key>IDESourceControlWCCName</key>
+			<string>MACollectionUtilities</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/README.markdown
+++ b/README.markdown
@@ -28,14 +28,14 @@ Methods are provided on `NSArray` and `NSSet` to do mapping, filtering, and matc
 * `ma_match:` - Search for an object in the collection for which the block returns `YES` and return it.
 * `ma_reduce:block:` - Start an accumulated value with the first argument. Call the block on each element of the array, passing it that element and the accumulated value so far. Set the accumulated value to the result. Allows an arbitrary "summation" operation to be performed on an array.
 * `ma_sorted:` - Use the block as a comparator to sort the array. Unlike the built-in Cocoa methods, the comparator returns a single `BOOL`, indicating whether the two objects should be sorted in ascending order. Note that this is different from the normal Cocoa technique of returning ascending, descending, or equal. Due to this difference, the comparator will be called somewhat more often than with the standard Cocoa methods, since it sometimes needs to be called twice to fully detect the ordering of a pair of objects.
-
+* `ma_do:` - Call the block once for each object in the collection. No result is collected.
 
 Helper macros
 -------------
 
 To simplify the use of the above methods, helper macros are provided. These macros take a collection as their first parameter and an expression as their second. The expression is used to create a block which is passed to the appropriate method. The parameter `obj` is implicitly created by most macros and can be used in the expression to refer to the individual objects.
 
-* The `MAP`, `SELECT`, and `MATCH` macros all correspond to the methods of the same names.
+* The `MAP`, `SELECT`, `MATCH`, and `DO` macros all correspond to the methods of the same names.
 * The `REJECT` macro is equivalent to a `SELECT` except that it selects objects for which the expression is *false*.
 * The `REDUCE` macro takes three arguments: the collection, the initial value, and the expression to use for reduction. This macro implicitly creates parameters `a` (the accumulated value) and `b` (the object from the array).
 * The `SORTED` macro implicitly creates parameters `a` and `b`, and the second parameter should be an expression which evaluates to true if `a` should be sorted before `b`.

--- a/main.m
+++ b/main.m
@@ -92,12 +92,16 @@ static void TestEach(void)
 {
     NSArray *array1 = ARRAY(@"1", @"2", @"3");
     NSArray *array2 = ARRAY(@"4", @"5", @"6");
+	__block NSInteger sum = 0;
     
     NSArray *together = MAP(array1, [obj stringByAppendingString: EACH(array2)]);
     TEST_ASSERT([together isEqual: ARRAY(@"14", @"25", @"36")]);
     
     NSArray *filtered = SELECT(array1, [obj intValue] * 2 < [EACH(array2) intValue]);
     TEST_ASSERT([filtered isEqual: ARRAY(@"1", @"2")]);
+	
+	DO (array1, sum += [[obj stringByAppendingString: EACH(array2)] integerValue]);
+	TEST_ASSERT (sum == 75);
 }
 
 static void TestSetMethods(void)
@@ -175,11 +179,16 @@ int main(int argc, char **argv)
         TEST(TestSorting);
         
         NSString *message;
+		
         if(gFailureCount)
+		{
             message = [NSString stringWithFormat: @"FAILED: %d total assertion failure%s", gFailureCount, gFailureCount > 1 ? "s" : ""];
+		}
         else
+		{
             message = @"SUCCESS";
+		}
         NSLog(@"Tests complete: %@", message);
     });
-    return 0;
+    return gFailureCount != 0;
 }

--- a/main.m
+++ b/main.m
@@ -103,7 +103,8 @@ static void TestEach(void)
 static void TestSetMethods(void)
 {
     NSSet *set = SET(@"1", @"2", @"3");
-    
+	__block NSInteger sum = 0;
+
     TEST_ASSERT([[set ma_map: ^(id obj) { return [obj stringByAppendingString: @".0"]; }] isEqual: 
                  SET(@"1.0", @"2.0", @"3.0")]);
     TEST_ASSERT([[set ma_select: ^BOOL (id obj) { return [obj intValue] < 1; }] isEqual: SET()]);
@@ -111,11 +112,15 @@ static void TestSetMethods(void)
     TEST_ASSERT([[set ma_select: ^BOOL (id obj) { return [obj intValue] < 4; }] isEqual: set]);
     TEST_ASSERT([SET(@"2", @"3") containsObject: [set ma_match: ^BOOL (id obj) { return [obj intValue] > 1; }]]);
     TEST_ASSERT([set ma_match: ^BOOL (id obj) { return [obj intValue] < 1; }] == nil);
+	
+	[set ma_do: ^void (id obj) { sum += [obj integerValue]; }];
+	TEST_ASSERT(sum == 6);
 }
 
 static void TestSetMacros(void)
 {
     NSSet *set = SET(@"1", @"2", @"3");
+	__block NSInteger sum = 0;
     
     TEST_ASSERT([MAP(set, [obj stringByAppendingString: @".0"]) isEqual: 
                  SET(@"1.0", @"2.0", @"3.0")]);
@@ -131,6 +136,9 @@ static void TestSetMacros(void)
     
     TEST_ASSERT([SET(@"2", @"3") containsObject: MATCH(set, [obj intValue] > 1)]);
     TEST_ASSERT(MATCH(set, [obj intValue] < 1) == nil);
+	
+	DO(set, sum += [obj integerValue]);
+	TEST_ASSERT (sum == 6);
 }
 
 static void TestReduce(void)

--- a/main.m
+++ b/main.m
@@ -50,6 +50,7 @@ static void TestCreation(void)
 static void TestArrayMethods(void)
 {
     NSArray *array = ARRAY(@"1", @"2", @"3");
+	__block NSInteger sum = 0;
     
     TEST_ASSERT([[array ma_map: ^(id obj) { return [obj stringByAppendingString: @".0"]; }] isEqual: 
                  ARRAY(@"1.0", @"2.0", @"3.0")]);
@@ -58,13 +59,17 @@ static void TestArrayMethods(void)
     TEST_ASSERT([[array ma_select: ^BOOL (id obj) { return [obj intValue] < 4; }] isEqual: array]);
     TEST_ASSERT([[array ma_match: ^BOOL (id obj) { return [obj intValue] > 1; }] isEqual: @"2"]);
     TEST_ASSERT([array ma_match: ^BOOL (id obj) { return [obj intValue] < 1; }] == nil);
+	
+	[array ma_do: ^void (id obj) { sum += [obj integerValue]; }];
+	TEST_ASSERT(sum == 6);
 }
 
 static void TestArrayMacros(void)
 {
     NSArray *array = ARRAY(@"1", @"2", @"3");
-    
-    TEST_ASSERT([MAP(array, [obj stringByAppendingString: @".0"]) isEqual: 
+	__block NSInteger sum = 0;
+
+    TEST_ASSERT([MAP(array, [obj stringByAppendingString: @".0"]) isEqual:
                  ARRAY(@"1.0", @"2.0", @"3.0")]);
     TEST_ASSERT([SELECT(array, [obj intValue] < 1) isEqual: ARRAY()]);
     TEST_ASSERT([SELECT(array, [obj intValue] < 3) isEqual: ARRAY(@"1", @"2")]);
@@ -78,6 +83,9 @@ static void TestArrayMacros(void)
     
     TEST_ASSERT([MATCH(array, [obj intValue] > 1) isEqual: @"2"]);
     TEST_ASSERT(MATCH(array, [obj intValue] < 1) == nil);
+	
+	DO(array, sum += [obj integerValue]);
+	TEST_ASSERT (sum == 6);
 }
 
 static void TestEach(void)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,2 @@
+xcodebuild CONFIGURATION_BUILD_DIR='.'
+./MACollectionUtilities


### PR DESCRIPTION
This pull request adds the `DO` macro to MACollectionUtilities, which a calls a block for each member of the collection without collecting any data.

Please think `DO` macro of it as a short-hand version of  NSArray's enumerateObjectsUsingBlock: , or any simple `for` loop, where there's no need to process or collect return values of the iterated code. 

Example:

Instead of
```
- (void) removeValidationResultsForListings:(NSArray*)inListings
{
	for (GSEbayListing *listing in inListings)
	{
		[self.validationErrorsPerListing removeObjectForKey:listing.uuid];
	}
}
```

one can now write:

```
- (void) removeValidationResultsForListings:(NSArray*)inListings
{
	DO (inListings, [self.validationErrorsPerListing removeObjectForKey:[obj uuid]]);
}
```

I also added a travis.yml file so the code is tested automatically when changes are pushed to GitHub. (You need to enable travis for your master branch on travis-ci.org, though).

P.S. I updated this pull request to make the DO macro support the parallel enumeration feature of MACollectionUtilities.